### PR TITLE
Para usar VM de menor rendimiento

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# Ejecuta Litd
+# Litd de LND
+## Curso Autocustodia Lighntning Network: Tu Nodo Lightning, Tus Reglas
 
 ![Alt text](/img/autocustodia_ln.webp "Ejecuta Litd")
 
@@ -33,9 +34,9 @@ Las versiones actuales de las listas de verificación y scripts instalan...
 
 Esta configuración está bien testeada en servidores barebone o virtulaes, con al menos este nivel de recursos:
 
-- 2+ Núcleos de CPU
-- 80GB+ de Almacenamiento (nodo podado a 50GB)
-- 2GB+ de RAM
+- 1 vCPU
+- 20GB de Almacenamiento (nodo podado a 2GB)
+- 1GB de RAM
 
 Deberá aumentar estos recursos cuando ejecute un servidor de producción o cuando ejecute un nodo completo.
 
@@ -128,7 +129,7 @@ Al ejecutar un nodo completo en mainnet, el servidor debe tener al menos 800 GB.
 
 Al ejecutar un nodo podado, la siguiente línea debe estar descomentada en el archivo **bitcoin.conf**. Es la opción por defecto del script.
 
-```prune=50000 # Podar a 50GB```
+```prune=2000 # Podar a 2GB```
 
 Ambos scripts también ejecutan comprobaciones para ver lo que se ha hecho a medida que avanzan, por lo que deberían ser seguros para ejecutar varias veces en caso de que alguna ejecución se haya interrumpido.
 
@@ -196,3 +197,6 @@ Para descagar el binario:
 ```sudo ./litd_setup3.sh```
 
 Ahora a desarrollar! 
+
+Autor: Federico Fox, Librería de Satoshi educator. 
+https://github.com/Foxtrot-Zulu

--- a/scripts/bitcoind_setup.sh
+++ b/scripts/bitcoind_setup.sh
@@ -114,7 +114,7 @@ cat <<EOF > $BITCOIN_CONF
 daemon=1
 
 # Establecer el número de megabytes de RAM a usar, establecer como en el 50% de la memoria disponible
-dbcache=3000
+dbcache=1000
 
 # Añadir visibilidad a la mempool y llamadas RPC para la depuración potencial de LND
 debug=mempool
@@ -151,8 +151,8 @@ shrinkdebuglog=1
 # Establecer signet si es necesario
 $( [[ "$NETWORK" == "signet" ]] && echo "signet=1" || echo "#signet=1" )
 
-# Podar la cadena de bloques. Ejemplo de poda a 50GB
-prune=50000
+# Podar la cadena de bloques. Ejemplo de poda a 2GB
+prune=2000
 
 # Activar el índice de búsqueda de transacciones, si el nodo podado está desactivado.
 txindex=0

--- a/scripts/bitcoind_setup_binary.sh
+++ b/scripts/bitcoind_setup_binary.sh
@@ -149,7 +149,7 @@ cat <<EOF > $BITCOIN_CONF
 daemon=1
 
 # Establecer el número de megabytes de RAM a usar, establecer en como el 50% de la memoria disponible
-dbcache=3000
+dbcache=1000
 
 # Añadir visibilidad al mempool y llamadas RPC para la depuración potencial de LND
 debug=mempool
@@ -186,8 +186,8 @@ shrinkdebuglog=1
 # Establecer signet si es necesario
 $( [[ "$NETWORK" == "signet" ]] && echo "signet=1" || echo "#signet=1" )
 
-# Podar la cadena de bloques. Ejemplo de poda a 50GB
-prune=50000
+# Podar la cadena de bloques. Ejemplo de poda a 2GB
+prune=2000
 
 # Activar el índice de búsqueda de transacciones, si el nodo podado está desactivado.
 txindex=0


### PR DESCRIPTION
Se modofica el Readme señalando que el entorno de prueba fue una máquina virtual de 1vCPU, 2GB de RAM y 20 GB de SSD. Además se modificaron los archivos bitcoind_setup.sh y bitcoind_setup_binary.sh para ajustar la RAM a 1GB (50% del de VM) y para la poda del nodo Bitcoin a 2GB.